### PR TITLE
Fix use of Path in find_outliers script.

### DIFF
--- a/scripts/find_outliers.py
+++ b/scripts/find_outliers.py
@@ -25,7 +25,7 @@ def print_outliers(data_directory):
         outlier_strs = []
         for out_ind in outliers:
             outlier_strs.append(str(out_ind))
-        print(', '.join([fname] + outlier_strs))
+        print(', '.join([str(fname)] + outlier_strs))
 
 
 def get_parser():


### PR DESCRIPTION
You may or may not need this pull-request.

There was a bug in the file `scripts/find_outliers.py` where the code uses a `fname` expecting a string, but in fact, by default, it will get a `Path` object.

You may have found and fixed that bug, in which case, you do not need this PR.

If you haven't already found and fixed this bug, then do merge this pull request.